### PR TITLE
initial commit for website Github-default

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,3 +1,7 @@
-# Welcome to my blog
+# Schön, dass Sie hierhergefunden haben!
 
-I'm glad you are here. I plan to talk about ...
+Sie befinden sich auf einer "Filiale" der Website der pflegenden Angehörigen SG aus Erfurt.
+Die aktuellen Nachrichten zu uns finden Sie momentan hier:
+https://edupad.ch/p/r.dce12f8d0714a1b8e96247a64af1ede
+
+Bleinem Sie gesund!


### PR DESCRIPTION
Änderung beim Start der Standardwebseite von Github gemäß des GeithubWebKurses zum anlegen einer Github-Webseite; allerdings beim Aufenthalt auf der Vorschau, den Änderungslink, welcher dort angezeigt wird genutzt, damit Abweichung vom Kursabluf
-> mal sehen was passiert?
---
- Zusätze gegenüber Standard:
 - them ausgewählt -> ist gesperrt wegen "gesperrtem commit"
 - grün/schwarzes Logo hochgeladen  -> mal sehen , war i.d. Vorschau nicht sichtbar
---
Die Gihub-Kursnaweisung zu diesem Schritt enthält nochmal die Aufforderung  zu einem 
"(,,,) and click Create a new branch for this commit (...)"
---
Activity: Create your homepage

    Navigate to the Code tab of this repository, and browse to the index.md file, or click this link here
    In the upper right corner, click the octicon-pencil icon to edit the index.md file
    Type the content you want on your homepage
    Scroll to the bottom, type a commit message, and click Create a new branch for this commit and start a pull request
    Open a pull request
